### PR TITLE
Workaround a bug in maven shade plugin

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ deploy_artifacts:
   stage: deploy
   script:
     - mvn ${MAVEN_MODIFY_CLI_OPTS} clean install -f pom-modify.xml
-    - mvn ${MAVEN_CLI_OPTS} clean install deploy -P java9 -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
+    - mvn ${MAVEN_CLI_OPTS} clean package deploy -P java9 -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
   only:
     refs:
       - master


### PR DESCRIPTION
Instead of using the install phase, use the package phase. The package phase is where the maven shade plugin runs. Maven deploy also runs package. It seems when running both phases in the context of the maven shade plugin, a mismatch in the generated shaded jar gets created more precisely; a duplicate entry in META-INF/services gets created.