### PR TITLE
Restore compatibility with upstream

### DIFF
--- a/neo4j-java-driver-feature/pom.xml
+++ b/neo4j-java-driver-feature/pom.xml
@@ -29,7 +29,7 @@
 
     <packaging>feature</packaging>
 
-    <name>Neo4j Java Driver Feature</name>
+    <name>Neo4j :: Java :: Driver :: Feature</name>
 
     <properties>
         <karaf-maven-plugin.version>4.3.0.RC1</karaf-maven-plugin.version>

--- a/pom-modify.xml
+++ b/pom-modify.xml
@@ -4,16 +4,19 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.neo4j.driver</groupId>
-    <artifactId>neo4j-java-driver-osgi</artifactId>
+    <artifactId>neo4j-java-driver-osgi-modify</artifactId>
     <version>4.1-SNAPSHOT</version>
 
-    <name>Neo4j Java Driver OSGi - Modify</name>
+    <name>Neo4j :: Java :: Driver :: OSGi :: Modify</name>
 
     <packaging>pom</packaging>
 
     <properties>
-        <pomutils-maven-plugin.version>1.1.0</pomutils-maven-plugin.version>
+        <artifactId-modifier>neo4j-java-driver-osgi</artifactId-modifier>
+        <reactor-bom-modifier.version>3.3.1.RELEASE</reactor-bom-modifier.version>
         <pomFile-to-alter>neo4j-java-driver/pom.xml</pomFile-to-alter>
+
+        <pomutils-maven-plugin.version>1.1.0</pomutils-maven-plugin.version>
     </properties>
 
     <build>
@@ -32,9 +35,51 @@
                             </goals>
                             <configuration>
                                 <groupId>${project.groupId}</groupId>
-                                <artifactId>${project.artifactId}</artifactId>
+                                <artifactId>${artifactId-modifier}</artifactId>
                                 <version>${project.version}</version>
                                 <pomFile>${pomFile-to-alter}</pomFile>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>delete-reactor-bom</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>delete-dependency</goal>
+                            </goals>
+                            <configuration>
+                                <groupId>io.projectreactor</groupId>
+                                <artifactId>reactor-bom</artifactId>
+                                <version>Dysprosium-SR7</version>
+                                <pomFile>${pomFile-to-alter}</pomFile>
+                                <modifyDependencyManagement>true</modifyDependencyManagement>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>add-reactor-core</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>add-dependency</goal>
+                            </goals>
+                            <configuration>
+                                <groupId>io.projectreactor</groupId>
+                                <artifactId>reactor-core</artifactId>
+                                <version>${reactor-bom-modifier.version}</version>
+                                <pomFile>${pomFile-to-alter}</pomFile>
+                                <modifyDependencyManagement>true</modifyDependencyManagement>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>add-reactor-test</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>add-dependency</goal>
+                            </goals>
+                            <configuration>
+                                <groupId>io.projectreactor</groupId>
+                                <artifactId>reactor-test</artifactId>
+                                <version>${reactor-bom-modifier.version}</version>
+                                <pomFile>${pomFile-to-alter}</pomFile>
+                                <modifyDependencyManagement>true</modifyDependencyManagement>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>neo4j-java-driver-osgi</artifactId>
     <version>4.1-SNAPSHOT</version>
 
-    <name>Neo4j Java Driver OSGi</name>
+    <name>Neo4j :: Java :: Driver :: OSGi</name>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
This merge request embeds a fix to a minor breaking change introduced in neo4j java driver. The project modifier gets instructed to remove a dependency lately introduced and add the two working ones.

The latest development version of neo4j java driver upstream upgraded the reactor dependency to version Dysprosium-SR7. The reactor library vendor also made some modifications in terms of OSGi metadata configuration. An error was identified in terms of avoiding a package from importing. The following merge request was provided to fix this problem. Ones a new release of the reactor library is available, the reactor version used in neo4j java driver has to be increased to that version.