### PR TITLE
Track fix OSGi 4.0 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "neo4j-java-driver"]
 	path = neo4j-java-driver
 	url = https://github.com/project-millipede/neo4j-java-driver.git
-	branch = Fix-OSGi
+	branch = Fix-OSGi-4.0

--- a/neo4j-java-driver-feature/pom.xml
+++ b/neo4j-java-driver-feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver-osgi</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <version>4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-java-driver-feature</artifactId>

--- a/pom-modify.xml
+++ b/pom-modify.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-osgi-modify</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.0-SNAPSHOT</version>
 
     <name>Neo4j :: Java :: Driver :: OSGi :: Modify</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.neo4j.driver</groupId>
     <artifactId>neo4j-java-driver-osgi</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.0-SNAPSHOT</version>
 
     <name>Neo4j :: Java :: Driver :: OSGi</name>
 


### PR DESCRIPTION
Among the in-development versions neo4j java driver 4.0 and 4.1, a rather significant change makes the driver and the current OGM version incompatible. Incompatibility is traced to integration tests, but some changes involve a check of client and server-side bolt protocol versions. For now, this repository tracks the revision 4.0 and deploys artifacts from the build.